### PR TITLE
Added in fixes for setting up vim as the default editor

### DIFF
--- a/gists/wsl_ubuntu_setup.sh
+++ b/gists/wsl_ubuntu_setup.sh
@@ -57,3 +57,4 @@ fi
 source ~/.bashrc
 sudo apt install -y unixodbc-dev pv
 sudo chsh -s /bin/zsh
+sudo update-alternatives --set editor /usr/bin/vim.basic


### PR DESCRIPTION
By default bionic ships with nano as the default editor.
Our team default is vim, so I updated the default
ubuntu editor globally by using `update-alternatives`.