### PR TITLE
[ISSUE-2]  Fixed up zsh tab completion for ubuntu ssh

### DIFF
--- a/gists/wsl_ubuntu_setup.sh
+++ b/gists/wsl_ubuntu_setup.sh
@@ -58,3 +58,4 @@ source ~/.bashrc
 sudo apt install -y unixodbc-dev pv
 sudo chsh -s /bin/zsh
 sudo update-alternatives --set editor /usr/bin/vim.basic
+sudo sed -Ei 's,HashKnownHosts\s+yes,HashKnownHosts no,g' /etc/ssh/ssh_config


### PR DESCRIPTION
by default, ubuntu hashes known hosts.  This prevents
zsh tab completion from working since zsh tab completion
relied on the hostname being present within the known
hosts file.  Disabling that default behavior allows zsh
tab completion for ssh to work normally.