### PR TITLE
Added lots of fun stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ Also included in this update:
 > Type a long string: echo "this is a super long string for us to try to use our new fun edit functionality on this will be something very cool for us to use in the future."
 > Once you push enter and go to new line type fc then press enter.
 > This will open up your last line in a vim window for easier editing! 
+
+## Update as of 10/1/2020
+### 1. Fix WSL resolv.conf
+>Type ```fix_resolv_conf``` in a new shell and the function will add the nameservers to your resolv.conf!
+
+### 2. Support for running Linux Bash commands in Windows Powershell
+Support for the bash commands:
+`"awk", "emacs", "grep", "head", "less", "ls", "man", "sed", "seq", "ssh", "tail", "touch"`
+has been added to powershell for use on the windows side of your windows machine. Tab completion for these commands 
+is included. 

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -98,3 +98,7 @@ fi
 #if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
 #    . /etc/bash_completion
 #fi
+
+export TUNDRA_ENV=local_docker
+
+fix_resolv_conf

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -199,3 +199,22 @@ if [ ! -e ~/.sqlplus_history ] ; then
     touch ~/.sqlplus_history
 fi
 
+if [[ -f /mnt/c/Program\ Files/Docker/Docker/resources/docker.exe ]] ; then
+    export PATH=$PATH:/mnt/c/Program\ Files/Docker/Docker/resources
+    alias docker="/mnt/c/Program\ Files/Docker/Docker/resources/docker.exe"
+fi
+
+if [[ -f /mnt/c/Program\ Files/Docker/Docker/resources/bin/docker-compose.exe ]] ; then
+    export PATH=$PATH:/mnt/c/Program\ Files/Docker/Docker/resources/bin
+    alias docker-compose="/mnt/c/Program\ Files/Docker/Docker/resources/bin/docker-compose.exe"
+fi
+
+
+function __fix_resolv_conf() {
+    sed -i '/\[network]/anameserver 172.17.10.8\nnameserver 172.17.11.8\nnameserver 172.22.4.2\n' /etc/resolv.conf
+}
+
+#Must be run as root
+function fix_resolv_conf() {
+    sudo zsh -c "$(functions __fix_resolv_conf); __fix_resolv_conf"
+}


### PR DESCRIPTION
@2ps I don't quite know how to get the zshrc to trigger the fix_resolv_conf function (in .zshrc) after the resolv.conf is generated. It seems the function changes are being clobbered by the WSL generation. Any ideas would be unreal.

The fix_resolv_conf function should allow people to write at least the current nameservers to the file.

The other functions basically add wsl.exe functions to powershell. Let me know if you want some other native bash functions added.