### PR TITLE
[GULP-648] update wsl_2_ip_address script to be able to be installed in

### DIFF
--- a/posh/wsl2_ip_address.ps1
+++ b/posh/wsl2_ip_address.ps1
@@ -1,3 +1,15 @@
+[CmdletBinding()]
+param(
+  [Parameter()][boolean]$install=$false
+)
+if ($install) {
+    Write-Host "installing"
+    $trigger = New-JobTrigger -AtStartup -RandomDelay 00:00:30
+    Register-ScheduledJob -Trigger $trigger -FilePath C:\u\dotfiles\posh\wsl2_ip_address.ps1 -Name set_wsl2_ip_address
+}
+
+wsl -d focal --shutdown
+Stop-Process -Name pycharm64
 import-module -Name c:\u\dotfiles\posh\hcn
 
 $network = @"


### PR DESCRIPTION
powershell job scheduler to run at startup.

Problem:

wsl2 will sometimes spawn ipaddresses that will conflict with our
internal networking thus causing the user connectivity issues in trying
to reach our network.

Solution:

run this job at computer startup and wsl2 will always spawn with an
ipcidr that does not conflict.